### PR TITLE
semver2 bump always tries to a prerelease tag

### DIFF
--- a/src/ctl/plugins/semver2.py
+++ b/src/ctl/plugins/semver2.py
@@ -49,7 +49,6 @@ class Semver2Plugin(VersionBasePlugin):
             "--prerelease",
             type=str,
             help="tag a prerelease with the specified prerlease name",
-            default="rc",
         )
 
         # operation `release`


### PR DESCRIPTION
fixes #39

fix bug where semver2 `bump` subparser still set a default value of `rc` for --prerelease - this should be explicitly provided instead as to not flag any release done through `bump` as a prerelease, this is inline with how the subparser for
 the `tag` command already handles this.
