### PR TITLE
template: should copy access permissions on files it copies (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - git plugin will now always set remote and branch for pull and push
 - semver2 plugin always trying to tag a prerelease during bump action (#39)
 - changelog version sorting issues during generate and release (#38)
+- template plugin will now copy file permissions (#37)
 ### Removed
 - version plugin: automatic creation of dev tags (#46)
 

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -9,6 +9,7 @@ Unreleased:
   - git plugin will now always set remote and branch for pull and push
   - semver2 plugin always trying to tag a prerelease during bump action (#39)
   - changelog version sorting issues during generate and release (#38)
+  - template plugin will now copy file permissions (#37)
   removed:
   - 'version plugin: automatic creation of dev tags (#46)'
 1.0.0:

--- a/src/ctl/plugins/template.py
+++ b/src/ctl/plugins/template.py
@@ -158,3 +158,5 @@ class TemplatePlugin(CopyPlugin):
         self.log.info(self.output(path))
         self.engine.render(path, out_dir=self.output(), env=self.tmpl_env)
         self.debug_append("rendered", self.output(path))
+
+        os.chmod(self.output(path), os.stat(self.source(path)).st_mode)

--- a/tests/test_plugin_template.py
+++ b/tests/test_plugin_template.py
@@ -1,4 +1,5 @@
 import os
+import stat
 
 from util import instantiate_test_plugin
 
@@ -28,10 +29,14 @@ def test_process(tmpdir, ctlr):
     plugin = instantiate(tmpdir, ctlr)
     plugin.execute()
 
-    assert len(plugin.debug_info["rendered"]) == 2
+    assert len(plugin.debug_info["rendered"]) == 3
     for processed in plugin.debug_info["rendered"]:
         with open(processed) as fh:
             assert fh.read() == "some content first variable\n"
+
+
+        if os.path.splitext(processed)[1] == ".sh":
+            assert bool(os.stat(processed).st_mode & stat.S_IXUSR)
 
 
 def test_expose_vars(tmpdir, ctlr):

--- a/tests/test_plugin_template.py
+++ b/tests/test_plugin_template.py
@@ -37,6 +37,9 @@ def test_process(tmpdir, ctlr):
 
         if os.path.splitext(processed)[1] == ".sh":
             assert bool(os.stat(processed).st_mode & stat.S_IXUSR)
+        else:
+            assert not bool(os.stat(processed).st_mode & stat.S_IXUSR)
+
 
 
 def test_expose_vars(tmpdir, ctlr):


### PR DESCRIPTION
fixes #37 

Currently when we template executables (.sh etc.) file permissions are lost in the templating process, this fixes that